### PR TITLE
Clean up server code and add room functionality

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -41,7 +41,7 @@ def assign_player_to_lobby(data):
     player_name = data['playerName']
     room = data['room']
 
-    # If join_room is called with an empty room ID, this user is joining for the first time. 
+    # If assign_player_to_lobby is called with an empty room ID, this user is joining for the first time. 
     # In the future, we will generate an ID for them. For now, all players join the "Multiplayer" room.
 
     if room == "":

--- a/server/app.py
+++ b/server/app.py
@@ -3,6 +3,7 @@ import os
 from flask import Flask, send_from_directory, json
 from flask_socketio import SocketIO, join_room, leave_room
 from flask_cors import CORS
+from collections import OrderedDict
 
 APP = Flask(__name__, static_folder='./build/static')
 
@@ -24,62 +25,58 @@ def on_disconnect():
     '''When someone disconnects to the server'''
     print('User disconnected!')
 
-USERS = {
-    'everyone': []
+ROOMS = {} 
+''' 
+ROOMS contains a dictionary of room ids, which maps to an ordered dictionary of player stats.
+Ex: ROOMS[1234] = {
+        'John': 97
+        'Matt': 84
+    }
 }
+'''
 
-@socketio.on('getUsers')
-def get_users(data):
-    '''Send data to all the clients'''
-
-    #if the players is not in the every active player list add it
-    if(data['playerName'] not in USERS['everyone']):
-        USERS['everyone'].append(data['playerName'])
-
-    socketio.emit('getUsers', USERS['everyone'], broadcast=True)
-
-USER_STATS = {}
-# server side code
-@socketio.on('joinRoom')
-def join_rooms(data):
+@socketio.on('assignPlayerToLobby')
+def assign_player_to_lobby(data):
     '''Put the user in a specified room'''
+    player_name = data['playerName']
+    room = data['room']
 
-    #Join the specified room
-    join_room(data['room'])
+    # If join_room is called with an empty room ID, this user is joining for the first time. 
+    # In the future, we will generate an ID for them. For now, all players join the "Multiplayer" room.
 
-    #if the 'room' is not in the USERS dic then add it
-    if(data['room'] not in USERS):
-        USERS[data['room']] = []
+    if room == "":
+        room = "Multiplayer"
 
-    #if the player is not in the rooms list, add it
-    if(data['playerName'] not in USERS[data['room']]):
-        USERS[data['room']].append(data['playerName'])
+    # Join the specified room
+    join_room(room)
 
+    # If the 'room' is not in ROOMS then add it
+    if room not in ROOMS:
+        ROOMS[room] = OrderedDict()
 
+    # If the player is not in the room then add them
+    if player_name not in ROOMS[room]:
+        ROOMS[room][player_name] = 0
+    socketio.emit('assignPlayerToLobby', {'activePlayers': list(ROOMS[room].keys()), 'room': room}, room=room) 
 
-@socketio.on('playerStats')
-def get_player_stats(data):
-    '''A client sends their WPM and the server sends the updated stats to all clients'''
+@socketio.on('updatePlayerStats')
+def update_player_stats(data):
+    '''A client sends their WPM and the server sends the updated stats to all clients in their room'''
+    room = data['room']
+    player_name = data['playerName']
+    wpm = data['wpm']
+    ROOMS[room][player_name] = wpm
+    socketio.emit('updatePlayerStats', {'playerStats': ROOMS[room]}, broadcast=True, room=room)
 
-    #update the currents users wpm
-    USER_STATS[data['playerName']] = data['wpm']
-    print(USER_STATS)
-    socketio.emit('playerStats', {'playerStats': USER_STATS}, broadcast=True, room=data['room'])
-
-@socketio.on('leaveRoom')
-def leave_rooms(data):
+@socketio.on('removePlayerFromLobby')
+def remove_player_from_lobby(data):
     '''User leaves the room'''
-
-    leave_room(data['room'])
-
-    #get the users index in a given room, and get rid of it
-    USER_INDEX = USERS[data['room']].index(data['playerName'])
-    USERS[data['room']].pop(USER_INDEX)
-
-    #get rid of the wpm for the user that left
-    USER_STATS.pop(data['playerName'])
-
-    socketio.emit('playerStats', {'playerStats': USER_STATS}, broadcast=True, room=data['room'])
+    room = data['room']
+    player_name = data['playerName']
+    # Remove the player from the room
+    ROOMS[room].pop(player_name, None)
+    socketio.emit('removePlayerFromLobby', {'activePlayers': list(ROOMS[room].keys()), 'room': room}, room=room) 
+    leave_room(room)
 
 
 @APP.route('/', defaults={"filename": "index.html"})

--- a/src/HomeScreen.js
+++ b/src/HomeScreen.js
@@ -7,45 +7,32 @@ import PlayerStats from './PlayerStats.js'
 export const socket = io(); // Connects to socket connection
 
 export default function Home ({playerName}) {
-  //state for joining multiplayer room or not
-  const [playerJoinedMultiplayer, setPlayerJoinedMultiplayer] = useState(false)
-  //state list of all players in all the rooms
-  const [activePlayers, setActivePlayers] = useState([])
-  const room = 'Multiplayer'
+  const [playerStartedGame, setPlayerStartedGame] = useState(false) // State for joining multiplayer room or not
+  const [activePlayers, setActivePlayers] = useState([]) // State list of all players in all the rooms
+  const [room, setRoom] = useState(""); // State for keeping track of the room the player is in
 
-  const leaveRoom = ()=>{
-    //when someone clicks the leave room button
-    socket.emit('leaveRoom', {playerName, room})
-    setPlayerJoinedMultiplayer(false)
-  }
-
-  const joinRoom = ()=>{
-    //when someone clicks the join room button
-    socket.emit('joinRoom', {playerName, room})
-    setPlayerJoinedMultiplayer(true)
-  }
   useEffect(() => {
-    //get all the active users from all the room
-    socket.emit('getUsers', {playerName})
-    socket.on('getUsers', (data)=>{
-      setActivePlayers(data);
+    socket.emit('assignPlayerToLobby', {playerName, room});
+    socket.on('assignPlayerToLobby', (data) => {
+      setActivePlayers(data.activePlayers);
+      setRoom(data.room)
     })
   }, [playerName])
 
   return (
     <div>
-      { playerJoinedMultiplayer
+      { playerStartedGame
       ? <div>
-          <button onClick={leaveRoom}>Back to Home-Screen</button>
+          <button onClick={() => setPlayerStartedGame(false)}>Back to Home Screen</button>
           <MainGameScreen playerName={playerName} room={room}/>
-          <PlayerStats />
+          <PlayerStats socket={socket}/>
         </div>
       : <div>
           Hi, {playerName}! Welcome to your lobby.
           <br></br>
           Current players:
           <UserList users={activePlayers}/>
-          <button onClick={joinRoom}> Join Game </button>
+          <button onClick={() => setPlayerStartedGame(true)}> Start Game </button>
         </div>
       }
     </div>

--- a/src/MainGameScreen.js
+++ b/src/MainGameScreen.js
@@ -5,28 +5,23 @@ import {socket} from './HomeScreen'
 const prompt = "One study examining 30 subjects, of varying different styles and expertise, has found minimal difference in typing speed between touch typists and self-taught hybrid typists. According to the study, 'The number of fingers does not determine typing speed... People using self-taught typing strategies were found to be as fast as trained typists... instead of the number of fingers, there are other factors that predict typing speed... fast typists... keep their hands fixed on one position, instead of moving them over the keyboard, and more consistently use the same finger to type a certain letter.' To quote doctoral candidate Anna Feit: 'We were surprised to observe that people who took a typing course, performed at similar average speed and accuracy, as those that taught typing to themselves and only used 6 fingers on average' (Wikipedia)";
 
 function MainGameScreen({playerName, room}) {
-  //input box when user types
-  const textboxRef = useRef();
-  //state for highlighting text to bold
-  const [highlightedStopIndex, setHighlightedStopIndex] = useState(0);
-  //state for calculating wpm
-  const [wpm, setWpm] = useState(0);
-  //sate for calculating time for wpm
-  const [timeLeft, setTimeLeft] = useState(60);
-  //state for when typing gets stated and stopped
-  const [typingBegan, setTypingBegan] = useState(false);
+  const textboxRef = useRef(); // Input box reference for when user types
+  const [highlightedStopIndex, setHighlightedStopIndex] = useState(0); // State for keeping track of the last character index to highlight in the prompt
+  const [wpm, setWpm] = useState(0); // State for calculating wpm
+  const [timeLeft, setTimeLeft] = useState(60); // State for keeping track of the time so that the wpm can be calculated
+  const [typingBegan, setTypingBegan] = useState(false); // State for checking if the userr started typing
 
   useEffect(() => {
-    //calculate wpm and set it in the state
+    // Calculate wpm and set it in the state
     let entries = highlightedStopIndex / 5;
     let currentMin = (60 - timeLeft) / 60;
     let wpm = currentMin === 0 ? 0 : Math.round(entries / currentMin);
     setWpm(wpm);
-    socket.emit('playerStats', {'playerName': playerName, 'wpm': wpm, 'room': room});
+    socket.emit('updatePlayerStats', {'playerName': playerName, 'wpm': wpm, 'room': room});
   }, [highlightedStopIndex, playerName, room, timeLeft])
 
   function onTextChanged() {
-    //called when user starts typing
+    // Called when user starts typing
     setTypingBegan(true);
     if (prompt.startsWith(textboxRef.current.value)) {
       setHighlightedStopIndex(textboxRef.current.value.length);
@@ -34,12 +29,12 @@ function MainGameScreen({playerName, room}) {
   }
 
   function promptJSX() {
-    //highlight the text
+    // Highlight the text
     return (<p><b>{prompt.substring(0, highlightedStopIndex)}</b>{prompt.substring(highlightedStopIndex)}</p>);
   }
 
   function handleTime(t) {
-    //calculate the time
+    // Decrement the timer and set the timeLeft state
     setTimeLeft(t);
     return t-1;
   }

--- a/src/PlayerStats.js
+++ b/src/PlayerStats.js
@@ -1,12 +1,10 @@
 import { React, useState, useEffect } from 'react';
-import {socket} from './HomeScreen'
 
-export default function PlayerStats () {
-  //state to keep track of all the active users wpm
-  const [activePlayerStats, setActivePlayerStats] = useState({})
+export default function PlayerStats ({socket}) {
+  const [activePlayerStats, setActivePlayerStats] = useState({}) // State to keep track of all the active users wpm
 
   useEffect( ()=> {
-    socket.on('playerStats', (data) => {
+    socket.on('updatePlayerStats', (data) => {
       setActivePlayerStats(data.playerStats);
     })
   }, [])
@@ -14,7 +12,7 @@ export default function PlayerStats () {
   return ( // We can eventually replace this with a chart
     <ul>
       { Object.entries(activePlayerStats).map(([key, index]) => {
-        return <li key={index}><b>{key}:</b> {activePlayerStats[key]}</li>
+        return <li key={key}><b>{key}:</b> {activePlayerStats[key]}</li>
       })}
     </ul>
   );


### PR DESCRIPTION
Created the `ROOMS` dictionary in app.py to manage all rooms on the backend. This should help to keep the backend code future-proof for when we start allowing players to invite each other and generate their own rooms. For now, all players are sent to one room called "Multiplayer". I also formatted some comments and changed variable named on the client-side.

@AP7557 you have most of the context on the backend. How do these changes look to you?